### PR TITLE
Fix styleUrls for components

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import { RouterOutlet } from '@angular/router';
   selector: 'app-root',
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'v2';

--- a/src/app/componentes/paginas/afiliados-links/afiliados-links.component.ts
+++ b/src/app/componentes/paginas/afiliados-links/afiliados-links.component.ts
@@ -7,7 +7,7 @@ import { FooterComponent } from "../../reutilizaveis/footer/footer.component";
   standalone: true,
   imports: [HeaderComponent, FooterComponent],
   templateUrl: './afiliados-links.component.html',
-  styleUrl: './afiliados-links.component.scss'
+  styleUrls: ['./afiliados-links.component.scss']
 })
 export class AfiliadosLinksComponent {
 

--- a/src/app/componentes/paginas/home/sections/contato/contato.component.ts
+++ b/src/app/componentes/paginas/home/sections/contato/contato.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   standalone: true,
   imports: [],
   templateUrl: './contato.component.html',
-  styleUrl: './contato.component.scss'
+  styleUrls: ['./contato.component.scss']
 })
 export class ContatoComponent {
 

--- a/src/app/componentes/paginas/home/sections/inicio/inicio.component.ts
+++ b/src/app/componentes/paginas/home/sections/inicio/inicio.component.ts
@@ -7,7 +7,7 @@ import { MenuRedesSociaisComponent } from '../../../../reutilizaveis/menu-redes-
   standalone: true,
   imports: [TranslateModule, MenuRedesSociaisComponent],
   templateUrl: './inicio.component.html',
-  styleUrl: './inicio.component.scss'
+  styleUrls: ['./inicio.component.scss']
 })
 
 export class InicioComponent {

--- a/src/app/componentes/paginas/home/sections/sobre/linha-do-tempo/card-experiencia-profissional/card-experiencia-profissional.component.ts
+++ b/src/app/componentes/paginas/home/sections/sobre/linha-do-tempo/card-experiencia-profissional/card-experiencia-profissional.component.ts
@@ -6,7 +6,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'app-card-experiencia-profissional',
   imports: [TranslateModule],
   templateUrl: './card-experiencia-profissional.component.html',
-  styleUrl: './card-experiencia-profissional.component.scss'
+  styleUrls: ['./card-experiencia-profissional.component.scss']
 })
 export class CardExperienciaProfissionalComponent {
   @Input() experienciaProfissional!: ExperienciaProfissional;

--- a/src/app/componentes/paginas/meus-links/meus-links.component.ts
+++ b/src/app/componentes/paginas/meus-links/meus-links.component.ts
@@ -11,7 +11,7 @@ import { Link } from '../../../../model/link.model';
   standalone: true,
   imports: [TranslateModule, CardComponent, FooterComponent, HeaderComponent],
   templateUrl: './meus-links.component.html',
-  styleUrl: './meus-links.component.scss'
+  styleUrls: ['./meus-links.component.scss']
 })
 export class MeusLinksComponent implements OnInit {
   links: Link[] = [];

--- a/src/app/componentes/reutilizaveis/dropdown-idiomas/dropdown-idiomas.component.ts
+++ b/src/app/componentes/reutilizaveis/dropdown-idiomas/dropdown-idiomas.component.ts
@@ -6,7 +6,7 @@ import { IdiomaService, Linguagem } from '../../../../services/idioma/idioma.ser
   selector: 'app-dropdown-idiomas',
   standalone: true,
   templateUrl: './dropdown-idiomas.component.html',
-  styleUrl: './dropdown-idiomas.component.scss',
+  styleUrls: ['./dropdown-idiomas.component.scss'],
 })
 export class DropdownIdiomasComponent {
   linguagens: Linguagem[] = [];

--- a/src/app/componentes/reutilizaveis/footer/footer.component.ts
+++ b/src/app/componentes/reutilizaveis/footer/footer.component.ts
@@ -9,7 +9,7 @@ import { Link } from '../../../../model/link.model';
   standalone: true,
   imports: [SwitchDiaNoiteComponent, DropdownIdiomasComponent, TranslateModule],
   templateUrl: './footer.component.html',
-  styleUrl: './footer.component.scss'
+  styleUrls: ['./footer.component.scss']
 })
 export class FooterComponent {
   @Input() links: Link[] = [];

--- a/src/app/componentes/reutilizaveis/header/header.component.ts
+++ b/src/app/componentes/reutilizaveis/header/header.component.ts
@@ -10,7 +10,7 @@ import { Link } from '../../../../model/link.model';
   standalone: true,
   imports: [TranslateModule, SwitchDiaNoiteComponent, DropdownIdiomasComponent],
   templateUrl: './header.component.html',
-  styleUrl: './header.component.scss'
+  styleUrls: ['./header.component.scss']
 })
 
 export class HeaderComponent {

--- a/src/app/componentes/reutilizaveis/menu-redes-sociais/menu-redes-sociais.component.ts
+++ b/src/app/componentes/reutilizaveis/menu-redes-sociais/menu-redes-sociais.component.ts
@@ -4,7 +4,7 @@ import { isPlatformBrowser } from '@angular/common';
 @Component({
   selector: 'app-menu-redes-sociais',
   templateUrl: './menu-redes-sociais.component.html',
-  styleUrl: './menu-redes-sociais.component.scss',
+  styleUrls: ['./menu-redes-sociais.component.scss'],
   standalone: true
 })
 export class MenuRedesSociaisComponent {

--- a/src/app/componentes/reutilizaveis/switch-dia-noite/switch-dia-noite.component.ts
+++ b/src/app/componentes/reutilizaveis/switch-dia-noite/switch-dia-noite.component.ts
@@ -8,7 +8,7 @@ import { TemaDiaNoiteService } from '../../../../services/tema-dia-noite/tema-di
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './switch-dia-noite.component.html',
-  styleUrl: './switch-dia-noite.component.scss'
+  styleUrls: ['./switch-dia-noite.component.scss']
 })
 export class SwitchDiaNoiteComponent implements OnInit {
   darkMode = false;


### PR DESCRIPTION
## Summary
- load component styles correctly by using `styleUrls` metadata

## Testing
- `npm test -- --browsers=ChromeHeadless --watch=false` *(fails: Cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6874774d6d308332ae0940f44918d1aa