### PR TITLE
Add promotions tabbed route

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,3 @@
-// app.config.ts
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,7 +5,7 @@ import { PromocoesComponent } from './componentes/paginas/promocoes/promocoes.co
 import { PromocoesMercadoLivreComponent } from './componentes/paginas/promocoes/promocoes-mercado-livre.component';
 import { PromocoesKabumComponent } from './componentes/paginas/promocoes/promocoes-kabum.component';
 import { PromocoesAmazonComponent } from './componentes/paginas/promocoes/promocoes-amazon.component';
-import { PromocoesAliExpressComponent } from './componentes/paginas/promocoes/promocoes-aliexpress.component';
+import { PromocoesAliexpressComponent } from './componentes/paginas/promocoes/promocoes-aliexpress.component';
 import { PromocoesShopeeComponent } from './componentes/paginas/promocoes/promocoes-shopee.component';
 
 export const routes: Routes = [
@@ -16,5 +16,5 @@ export const routes: Routes = [
     { path: 'promocoes/amazon', component: PromocoesAmazonComponent },
     { path: 'promocoes/kabum', component: PromocoesKabumComponent },
     { path: 'promocoes/shopee', component: PromocoesShopeeComponent },
-    { path: 'promocoes/aliexpress', component: PromocoesAliExpressComponent },
+    { path: 'promocoes/aliexpress', component: PromocoesAliexpressComponent },
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,8 +1,20 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from './componentes/paginas/home/home.component';
 import { MeusLinksComponent } from './componentes/paginas/meus-links/meus-links.component';
+import { PromocoesComponent } from './componentes/paginas/promocoes/promocoes.component';
+import { PromocoesMercadoLivreComponent } from './componentes/paginas/promocoes/promocoes-mercado-livre.component';
+import { PromocoesKabumComponent } from './componentes/paginas/promocoes/promocoes-kabum.component';
+import { PromocoesAmazonComponent } from './componentes/paginas/promocoes/promocoes-amazon.component';
+import { PromocoesAliExpressComponent } from './componentes/paginas/promocoes/promocoes-aliexpress.component';
+import { PromocoesShopeeComponent } from './componentes/paginas/promocoes/promocoes-shopee.component';
 
 export const routes: Routes = [
     { path: '', component: HomeComponent },
     { path: 'links-uteis', component: MeusLinksComponent },
+    { path: 'promocoes', component: PromocoesComponent },
+    { path: 'promocoes/mercado-livre', component: PromocoesMercadoLivreComponent },
+    { path: 'promocoes/amazon', component: PromocoesAmazonComponent },
+    { path: 'promocoes/kabum', component: PromocoesKabumComponent },
+    { path: 'promocoes/shopee', component: PromocoesShopeeComponent },
+    { path: 'promocoes/aliexpress', component: PromocoesAliExpressComponent },
 ];

--- a/src/app/componentes/paginas/home/sections/projetos/carrossel/macbook/macbook.component.ts
+++ b/src/app/componentes/paginas/home/sections/projetos/carrossel/macbook/macbook.component.ts
@@ -1,4 +1,3 @@
-// macbook.component.ts
 import { Component, Input } from '@angular/core';
 import { Projeto } from '../../../../../../../../model/projeto.model';
 

--- a/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.html
@@ -1,0 +1,13 @@
+<body>
+  <app-header />
+  <section class="section-promocoes">
+    <div class="container-promocoes">
+      <div class="row row-cols-1 row-cols-md-3 g-3">
+        <div class="col" *ngFor="let p of produtos">
+          <app-card-promocao [promocao]="p" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <app-footer />
+</body>

--- a/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.scss
+++ b/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.scss
@@ -1,0 +1,12 @@
+.section-promocoes {
+  margin-top: 10vh;
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--color-secondary);
+  padding: 1rem;
+}
+
+.container-promocoes {
+  max-width: 1400px;
+  margin-inline: auto;
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from '../../reutilizaveis/header/header.component';
+import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
+import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { PROMOCOES } from '../../data/promocoes';
+import { Promocao } from '../../../model/promocao.model';
+
+@Component({
+  selector: 'app-promocoes-aliexpress',
+  standalone: true,
+  imports: [CommonModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  templateUrl: './promocoes-aliexpress.component.html',
+  styleUrls: ['./promocoes-aliexpress.component.scss']
+})
+export class PromocoesAliexpressComponent {
+  produtos: Promocao[] = PROMOCOES.filter(p => p.store === 'aliexpress');
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-aliexpress.component.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
-import { PROMOCOES } from '../../data/promocoes';
-import { Promocao } from '../../../model/promocao.model';
+import { PROMOCOES } from '../../../data/promocoes';
+import { Promocao } from '../../../../model/promocao.model';
 
 @Component({
   selector: 'app-promocoes-aliexpress',

--- a/src/app/componentes/paginas/promocoes/promocoes-amazon.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes-amazon.component.html
@@ -1,0 +1,13 @@
+<body>
+  <app-header />
+  <section class="section-promocoes">
+    <div class="container-promocoes">
+      <div class="row row-cols-1 row-cols-md-3 g-3">
+        <div class="col" *ngFor="let p of produtos">
+          <app-card-promocao [promocao]="p" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <app-footer />
+</body>

--- a/src/app/componentes/paginas/promocoes/promocoes-amazon.component.scss
+++ b/src/app/componentes/paginas/promocoes/promocoes-amazon.component.scss
@@ -1,0 +1,12 @@
+.section-promocoes {
+  margin-top: 10vh;
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--color-secondary);
+  padding: 1rem;
+}
+
+.container-promocoes {
+  max-width: 1400px;
+  margin-inline: auto;
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-amazon.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-amazon.component.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
-import { PROMOCOES } from '../../data/promocoes';
-import { Promocao } from '../../../model/promocao.model';
+import { PROMOCOES } from '../../../data/promocoes';
+import { Promocao } from '../../../../model/promocao.model';
 
 @Component({
   selector: 'app-promocoes-amazon',

--- a/src/app/componentes/paginas/promocoes/promocoes-amazon.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-amazon.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from '../../reutilizaveis/header/header.component';
+import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
+import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { PROMOCOES } from '../../data/promocoes';
+import { Promocao } from '../../../model/promocao.model';
+
+@Component({
+  selector: 'app-promocoes-amazon',
+  standalone: true,
+  imports: [CommonModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  templateUrl: './promocoes-amazon.component.html',
+  styleUrls: ['./promocoes-amazon.component.scss']
+})
+export class PromocoesAmazonComponent {
+  produtos: Promocao[] = PROMOCOES.filter(p => p.store === 'amazon');
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-kabum.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes-kabum.component.html
@@ -1,0 +1,13 @@
+<body>
+  <app-header />
+  <section class="section-promocoes">
+    <div class="container-promocoes">
+      <div class="row row-cols-1 row-cols-md-3 g-3">
+        <div class="col" *ngFor="let p of produtos">
+          <app-card-promocao [promocao]="p" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <app-footer />
+</body>

--- a/src/app/componentes/paginas/promocoes/promocoes-kabum.component.scss
+++ b/src/app/componentes/paginas/promocoes/promocoes-kabum.component.scss
@@ -1,0 +1,12 @@
+.section-promocoes {
+  margin-top: 10vh;
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--color-secondary);
+  padding: 1rem;
+}
+
+.container-promocoes {
+  max-width: 1400px;
+  margin-inline: auto;
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-kabum.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-kabum.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from '../../reutilizaveis/header/header.component';
+import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
+import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { PROMOCOES } from '../../data/promocoes';
+import { Promocao } from '../../../model/promocao.model';
+
+@Component({
+  selector: 'app-promocoes-kabum',
+  standalone: true,
+  imports: [CommonModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  templateUrl: './promocoes-kabum.component.html',
+  styleUrls: ['./promocoes-kabum.component.scss']
+})
+export class PromocoesKabumComponent {
+  produtos: Promocao[] = PROMOCOES.filter(p => p.store === 'kabum');
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-kabum.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-kabum.component.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
-import { PROMOCOES } from '../../data/promocoes';
-import { Promocao } from '../../../model/promocao.model';
+import { PROMOCOES } from '../../../data/promocoes';
+import { Promocao } from '../../../../model/promocao.model';
 
 @Component({
   selector: 'app-promocoes-kabum',

--- a/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.html
@@ -1,0 +1,13 @@
+<body>
+  <app-header />
+  <section class="section-promocoes">
+    <div class="container-promocoes">
+      <div class="row row-cols-1 row-cols-md-3 g-3">
+        <div class="col" *ngFor="let p of produtos">
+          <app-card-promocao [promocao]="p" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <app-footer />
+</body>

--- a/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.scss
+++ b/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.scss
@@ -1,0 +1,12 @@
+.section-promocoes {
+  margin-top: 10vh;
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--color-secondary);
+  padding: 1rem;
+}
+
+.container-promocoes {
+  max-width: 1400px;
+  margin-inline: auto;
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
-import { PROMOCOES } from '../../data/promocoes';
-import { Promocao } from '../../../model/promocao.model';
+import { PROMOCOES } from '../../../data/promocoes';
+import { Promocao } from '../../../../model/promocao.model';
 
 @Component({
   selector: 'app-promocoes-mercado-livre',

--- a/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-mercado-livre.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from '../../reutilizaveis/header/header.component';
+import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
+import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { PROMOCOES } from '../../data/promocoes';
+import { Promocao } from '../../../model/promocao.model';
+
+@Component({
+  selector: 'app-promocoes-mercado-livre',
+  standalone: true,
+  imports: [CommonModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  templateUrl: './promocoes-mercado-livre.component.html',
+  styleUrls: ['./promocoes-mercado-livre.component.scss']
+})
+export class PromocoesMercadoLivreComponent {
+  produtos: Promocao[] = PROMOCOES.filter(p => p.store === 'mercado-livre');
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-shopee.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes-shopee.component.html
@@ -1,0 +1,13 @@
+<body>
+  <app-header />
+  <section class="section-promocoes">
+    <div class="container-promocoes">
+      <div class="row row-cols-1 row-cols-md-3 g-3">
+        <div class="col" *ngFor="let p of produtos">
+          <app-card-promocao [promocao]="p" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <app-footer />
+</body>

--- a/src/app/componentes/paginas/promocoes/promocoes-shopee.component.scss
+++ b/src/app/componentes/paginas/promocoes/promocoes-shopee.component.scss
@@ -1,0 +1,12 @@
+.section-promocoes {
+  margin-top: 10vh;
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--color-secondary);
+  padding: 1rem;
+}
+
+.container-promocoes {
+  max-width: 1400px;
+  margin-inline: auto;
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-shopee.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-shopee.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from '../../reutilizaveis/header/header.component';
+import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
+import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { PROMOCOES } from '../../data/promocoes';
+import { Promocao } from '../../../model/promocao.model';
+
+@Component({
+  selector: 'app-promocoes-shopee',
+  standalone: true,
+  imports: [CommonModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  templateUrl: './promocoes-shopee.component.html',
+  styleUrls: ['./promocoes-shopee.component.scss']
+})
+export class PromocoesShopeeComponent {
+  produtos: Promocao[] = PROMOCOES.filter(p => p.store === 'shopee');
+}

--- a/src/app/componentes/paginas/promocoes/promocoes-shopee.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes-shopee.component.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
-import { PROMOCOES } from '../../data/promocoes';
-import { Promocao } from '../../../model/promocao.model';
+import { PROMOCOES } from '../../../data/promocoes';
+import { Promocao } from '../../../../model/promocao.model';
 
 @Component({
   selector: 'app-promocoes-shopee',

--- a/src/app/componentes/paginas/promocoes/promocoes.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes.component.html
@@ -1,0 +1,46 @@
+<body>
+  <app-header />
+  <section class="section-promocoes">
+    <div class="container-promocoes">
+      <ul class="nav nav-tabs">
+        <li class="nav-item" *ngFor="let tab of tabs">
+          <a href="#" class="nav-link" [class.active]="activeTab===tab" (click)="activeTab=tab; $event.preventDefault();">{{ tab | titlecase }}</a>
+        </li>
+      </ul>
+
+      <div class="tab-content pt-3">
+        <div class="tab-pane" [class.active]="activeTab==='home'">
+          <h3>Novidades</h3>
+          <div class="row row-cols-1 row-cols-md-3 g-3">
+            <div class="col" *ngFor="let p of newest">
+              <app-card-promocao [promocao]="p" />
+            </div>
+          </div>
+
+          <h3 class="mt-4">Em Alta</h3>
+          <div class="row row-cols-1 row-cols-md-3 g-3">
+            <div class="col" *ngFor="let p of trending">
+              <app-card-promocao [promocao]="p" />
+            </div>
+          </div>
+
+          <div class="mt-4 converter-link">
+            <label class="form-label">Cole o link para converter</label>
+            <input type="text" class="form-control" [(ngModel)]="linkOriginal" placeholder="https://">
+            <button class="btn btn-secondary mt-2" (click)="gerarLink()">Gerar Link Afiliado</button>
+            <input *ngIf="linkAfiliado" type="text" class="form-control mt-2" [value]="linkAfiliado" readonly>
+          </div>
+        </div>
+
+        <div class="tab-pane" *ngFor="let tab of tabs.slice(1)" [class.active]="activeTab===tab">
+          <div class="row row-cols-1 row-cols-md-3 g-3">
+            <div class="col" *ngFor="let p of filtrar(tab)">
+              <app-card-promocao [promocao]="p" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <app-footer />
+</body>

--- a/src/app/componentes/paginas/promocoes/promocoes.component.scss
+++ b/src/app/componentes/paginas/promocoes/promocoes.component.scss
@@ -1,0 +1,12 @@
+.section-promocoes {
+  margin-top: 10vh;
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--color-secondary);
+  padding: 1rem;
+}
+
+.container-promocoes {
+  max-width: 1400px;
+  margin-inline: auto;
+}

--- a/src/app/componentes/paginas/promocoes/promocoes.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes.component.ts
@@ -4,8 +4,8 @@ import { FormsModule } from '@angular/forms';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
-import { PROMOCOES } from '../../data/promocoes';
-import { Promocao } from '../../../model/promocao.model';
+import { PROMOCOES } from '../../../data/promocoes';
+import { Promocao } from '../../../../model/promocao.model';
 
 @Component({
   selector: 'app-promocoes',

--- a/src/app/componentes/paginas/promocoes/promocoes.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HeaderComponent } from '../../reutilizaveis/header/header.component';
+import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
+import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { PROMOCOES } from '../../data/promocoes';
+import { Promocao } from '../../../model/promocao.model';
+
+@Component({
+  selector: 'app-promocoes',
+  standalone: true,
+  imports: [CommonModule, FormsModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  templateUrl: './promocoes.component.html',
+  styleUrls: ['./promocoes.component.scss']
+})
+export class PromocoesComponent {
+  tabs = ['home', 'mercado-livre', 'kabum', 'amazon', 'aliexpress', 'shopee'];
+  activeTab = 'home';
+
+  linkOriginal = '';
+  linkAfiliado = '';
+
+  newest: Promocao[] = PROMOCOES.slice(0, 3);
+  trending: Promocao[] = PROMOCOES.slice(3, 6);
+
+  filtrar(store: string): Promocao[] {
+    return PROMOCOES.filter(p => p.store === store);
+  }
+
+  gerarLink() {
+    this.linkAfiliado = this.linkOriginal
+      ? `https://meuslinks.com?url=${encodeURIComponent(this.linkOriginal)}`
+      : '';
+  }
+}

--- a/src/app/componentes/reutilizaveis/card-promocao/card-promocao.component.html
+++ b/src/app/componentes/reutilizaveis/card-promocao/card-promocao.component.html
@@ -1,0 +1,9 @@
+<div class="card h-100">
+  <img [src]="promocao.image" class="card-img-top" [alt]="promocao.title">
+  <div class="card-body d-flex flex-column">
+    <h5 class="card-title">{{ promocao.title }}</h5>
+    <p class="card-text flex-grow-1">{{ promocao.description }}</p>
+    <p class="card-text fw-bold">{{ promocao.price }}</p>
+    <a [href]="promocao.link" target="_blank" class="btn btn-primary mt-auto">Ver oferta</a>
+  </div>
+</div>

--- a/src/app/componentes/reutilizaveis/card-promocao/card-promocao.component.scss
+++ b/src/app/componentes/reutilizaveis/card-promocao/card-promocao.component.scss
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+}
+.card {
+  background-color: var(--color-primary);
+  color: var(--color-text-title);
+}

--- a/src/app/componentes/reutilizaveis/card-promocao/card-promocao.component.ts
+++ b/src/app/componentes/reutilizaveis/card-promocao/card-promocao.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Promocao } from '../../../../model/promocao.model';
+
+@Component({
+  selector: 'app-card-promocao',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './card-promocao.component.html',
+  styleUrls: ['./card-promocao.component.scss']
+})
+export class CardPromocaoComponent {
+  @Input() promocao!: Promocao;
+}

--- a/src/app/data/promocoes.ts
+++ b/src/app/data/promocoes.ts
@@ -1,0 +1,14 @@
+import { Promocao } from '../../model/promocao.model';
+
+export const PROMOCOES: Promocao[] = [
+  new Promocao('mercado-livre', 'Notebook Gamer', 'Notebook de alto desempenho', 'R$ 4.599,00', 'assets/images/macbook.png', 'https://example.com/ml-notebook'),
+  new Promocao('mercado-livre', 'Fone Bluetooth', 'Fone sem fio com cancelamento de ruído', 'R$ 299,00', 'assets/images/macbook.png', 'https://example.com/ml-fone'),
+  new Promocao('kabum', 'Mouse Gamer', 'Mouse ergonômico com RGB', 'R$ 199,90', 'assets/images/macbook.png', 'https://example.com/kabum-mouse'),
+  new Promocao('kabum', 'Teclado Mecânico', 'Switches azuis, layout ABNT2', 'R$ 399,90', 'assets/images/macbook.png', 'https://example.com/kabum-teclado'),
+  new Promocao('amazon', 'Echo Dot', 'Smart speaker com Alexa', 'R$ 349,00', 'assets/images/macbook.png', 'https://example.com/amazon-echo'),
+  new Promocao('amazon', 'Kindle 11ª Geração', 'Leitor digital com luz embutida', 'R$ 499,00', 'assets/images/macbook.png', 'https://example.com/amazon-kindle'),
+  new Promocao('aliexpress', 'Lâmpada Inteligente', 'Compatível com assistentes virtuais', 'R$ 89,90', 'assets/images/macbook.png', 'https://example.com/aliexpress-lampada'),
+  new Promocao('aliexpress', 'Câmera Wi-Fi', 'Monitoramento remoto via app', 'R$ 159,90', 'assets/images/macbook.png', 'https://example.com/aliexpress-camera'),
+  new Promocao('shopee', 'Capinha para Smartphone', 'Várias cores e modelos', 'R$ 29,90', 'assets/images/macbook.png', 'https://example.com/shopee-capinha'),
+  new Promocao('shopee', 'Suporte Veicular', 'Suporte magnético para celular', 'R$ 39,90', 'assets/images/macbook.png', 'https://example.com/shopee-suporte')
+];

--- a/src/app/i18n-init.ts
+++ b/src/app/i18n-init.ts
@@ -33,7 +33,7 @@ export function provideI18nSupport(): Provider {
             const detectedLang = supported.find(l => lang.includes(l)) || fallbackLang;
 
             translate.setDefaultLang(fallbackLang);
-            return translate.use(detectedLang).toPromise(); // Aguarda o carregamento do JSON
+            return translate.use(detectedLang).toPromise();
         },
         multi: true
     };

--- a/src/model/promocao.model.ts
+++ b/src/model/promocao.model.ts
@@ -1,0 +1,10 @@
+export class Promocao {
+    constructor(
+        public store: string,
+        public title: string,
+        public description: string,
+        public price: string,
+        public image: string,
+        public link: string
+    ) {}
+}

--- a/src/services/tema-dia-noite/tema-dia-noite.service.ts
+++ b/src/services/tema-dia-noite/tema-dia-noite.service.ts
@@ -11,7 +11,7 @@ export class TemaDiaNoiteService {
   private isBrowser: boolean;
   private objetoTema: BehaviorSubject<boolean>;
 
-  darkMode$ = new BehaviorSubject<boolean>(false).asObservable(); // temporário
+  darkMode$ = new BehaviorSubject<boolean>(false).asObservable();
 
   constructor(@Inject(PLATFORM_ID) private platformId: Object) {
     this.isBrowser = isPlatformBrowser(this.platformId);


### PR DESCRIPTION
## Summary
- add `Promocao` model and demo data
- create reusable promotion card component
- add `/promocoes` page with tabbed view and link converter
- add store specific pages for Mercado Livre, Kabum, Amazon, AliExpress and Shopee
- register new routes

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68750045fd0c8332b0f0613a20ff0bdf