### PR TITLE
Adicionar integração com Amazon PA API

### DIFF
--- a/src/app/componentes/paginas/promocoes/promocoes.component.html
+++ b/src/app/componentes/paginas/promocoes/promocoes.component.html
@@ -33,7 +33,15 @@
         </div>
 
         <div class="tab-pane" *ngFor="let tab of tabs.slice(1)" [class.active]="activeTab===tab">
-          <div class="row row-cols-1 row-cols-md-3 g-3">
+          <div *ngIf="tab==='amazon'">
+            <div *ngIf="carregandoAmazon" class="text-center">Carregando...</div>
+            <div class="row row-cols-1 row-cols-md-3 g-3">
+              <div class="col" *ngFor="let p of produtosAmazon">
+                <app-card-produto-amazon [produto]="p" />
+              </div>
+            </div>
+          </div>
+          <div *ngIf="tab!=='amazon'" class="row row-cols-1 row-cols-md-3 g-3">
             <div class="col" *ngFor="let p of filtrar(tab)">
               <app-card-promocao [promocao]="p" />
             </div>

--- a/src/app/componentes/paginas/promocoes/promocoes.component.ts
+++ b/src/app/componentes/paginas/promocoes/promocoes.component.ts
@@ -1,20 +1,23 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HeaderComponent } from '../../reutilizaveis/header/header.component';
 import { FooterComponent } from '../../reutilizaveis/footer/footer.component';
 import { CardPromocaoComponent } from '../../reutilizaveis/card-promocao/card-promocao.component';
+import { CardProdutoAmazonComponent } from '../../reutilizaveis/card-produto-amazon/card-produto-amazon.component';
 import { PROMOCOES } from '../../../data/promocoes';
 import { Promocao } from '../../../../model/promocao.model';
+import { ProdutoAfiliadoAmazon } from '../../../../model/produto-afiliado-amazon.model';
+import { PromocaoAmazonService } from '../../../../services/amazon/promocao-amazon.service';
 
 @Component({
   selector: 'app-promocoes',
   standalone: true,
-  imports: [CommonModule, FormsModule, HeaderComponent, FooterComponent, CardPromocaoComponent],
+  imports: [CommonModule, FormsModule, HeaderComponent, FooterComponent, CardPromocaoComponent, CardProdutoAmazonComponent],
   templateUrl: './promocoes.component.html',
   styleUrls: ['./promocoes.component.scss']
 })
-export class PromocoesComponent {
+export class PromocoesComponent implements OnInit {
   tabs = ['home', 'mercado-livre', 'kabum', 'amazon', 'aliexpress', 'shopee'];
   activeTab = 'home';
 
@@ -24,6 +27,15 @@ export class PromocoesComponent {
   newest: Promocao[] = PROMOCOES.slice(0, 3);
   trending: Promocao[] = PROMOCOES.slice(3, 6);
 
+  produtosAmazon: ProdutoAfiliadoAmazon[] = [];
+  carregandoAmazon = false;
+
+  constructor(private servicoAmazon: PromocaoAmazonService) { }
+
+  ngOnInit(): void {
+    this.carregarAmazon();
+  }
+
   filtrar(store: string): Promocao[] {
     return PROMOCOES.filter(p => p.store === store);
   }
@@ -32,5 +44,18 @@ export class PromocoesComponent {
     this.linkAfiliado = this.linkOriginal
       ? `https://meuslinks.com?url=${encodeURIComponent(this.linkOriginal)}`
       : '';
+  }
+
+  private carregarAmazon() {
+    this.carregandoAmazon = true;
+    this.servicoAmazon.listarPromocoes().subscribe({
+      next: produtos => {
+        this.produtosAmazon = produtos;
+        this.carregandoAmazon = false;
+      },
+      error: () => {
+        this.carregandoAmazon = false;
+      }
+    });
   }
 }

--- a/src/app/componentes/reutilizaveis/card-produto-amazon/card-produto-amazon.component.html
+++ b/src/app/componentes/reutilizaveis/card-produto-amazon/card-produto-amazon.component.html
@@ -1,0 +1,8 @@
+<div class="card h-100">
+  <img [src]="produto.imagem" class="card-img-top" [alt]="produto.nome">
+  <div class="card-body d-flex flex-column">
+    <h5 class="card-title">{{ produto.nome }}</h5>
+    <p class="card-text fw-bold">{{ produto.preco }}</p>
+    <a [href]="produto.link" target="_blank" class="btn btn-primary mt-auto">Ver na Amazon</a>
+  </div>
+</div>

--- a/src/app/componentes/reutilizaveis/card-produto-amazon/card-produto-amazon.component.scss
+++ b/src/app/componentes/reutilizaveis/card-produto-amazon/card-produto-amazon.component.scss
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+}
+.card {
+  background-color: var(--color-primary);
+  color: var(--color-text-title);
+}

--- a/src/app/componentes/reutilizaveis/card-produto-amazon/card-produto-amazon.component.ts
+++ b/src/app/componentes/reutilizaveis/card-produto-amazon/card-produto-amazon.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ProdutoAfiliadoAmazon } from '../../../../model/produto-afiliado-amazon.model';
+
+@Component({
+  selector: 'app-card-produto-amazon',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './card-produto-amazon.component.html',
+  styleUrls: ['./card-produto-amazon.component.scss']
+})
+export class CardProdutoAmazonComponent {
+  @Input() produto!: ProdutoAfiliadoAmazon;
+}

--- a/src/model/produto-afiliado-amazon.model.ts
+++ b/src/model/produto-afiliado-amazon.model.ts
@@ -1,0 +1,8 @@
+export class ProdutoAfiliadoAmazon {
+  constructor(
+    public nome: string,
+    public imagem: string,
+    public preco: string,
+    public link: string
+  ) {}
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,8 @@ import {
 import express from 'express';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { AmazonPaApiService } from './services/amazon/amazon-paapi.service';
+import { ProdutoAfiliadoAmazon } from './model/produto-afiliado-amazon.model';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
@@ -14,17 +16,25 @@ const browserDistFolder = resolve(serverDistFolder, '../browser');
 const app = express();
 const angularApp = new AngularNodeAppEngine();
 
+const paapi = new AmazonPaApiService();
+
 /**
- * Example Express Rest API endpoints can be defined here.
- * Uncomment and define endpoints as necessary.
- *
- * Example:
- * ```ts
- * app.get('/api/**', (req, res) => {
- *   // Handle API request
- * });
- * ```
+ * Endpoints da API utilizados pelo aplicativo Angular
  */
+app.get('/api/amazon/promocoes', async (_req, res) => {
+  try {
+    const palavras = ['cadeira gamer', 'monitor', 'notebook'];
+    const produtos = [] as ProdutoAfiliadoAmazon[];
+    for (const p of palavras) {
+      const itens = await paapi.buscarProdutos(p);
+      produtos.push(...itens);
+    }
+    res.json(produtos);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ erro: 'Erro ao consultar a Amazon' });
+  }
+});
 
 /**
  * Serve static files from /browser

--- a/src/services/amazon/amazon-paapi.service.ts
+++ b/src/services/amazon/amazon-paapi.service.ts
@@ -1,0 +1,114 @@
+import crypto from 'crypto';
+import { ProdutoAfiliadoAmazon } from '../../model/produto-afiliado-amazon.model';
+
+export class AmazonPaApiService {
+  private host = 'webservices.amazon.com';
+  private region = 'us-east-1';
+  private service = 'ProductAdvertisingAPI';
+
+  private accessKey = process.env['CHAVE_DE_ACESSO'] || '';
+  private secretKey = process.env['CHAVE_SECRETA'] || '';
+  private tag = process.env['TAG_AFILIADO'] || '';
+
+  async buscarProdutos(palavra: string): Promise<ProdutoAfiliadoAmazon[]> {
+    const payload = JSON.stringify({
+      Keywords: palavra,
+      PartnerTag: this.tag,
+      PartnerType: 'Associates',
+      Resources: [
+        'Images.Primary.Large',
+        'ItemInfo.Title',
+        'Offers.Listings.Price'
+      ]
+    });
+
+    const headers = this.assinarRequisicao('/paapi5/searchitems', payload);
+
+    const resposta = await fetch(`https://${this.host}/paapi5/searchitems`, {
+      method: 'POST',
+      headers,
+      body: payload
+    });
+
+    if (!resposta.ok) {
+      throw new Error(`Erro ao consultar PA API: ${resposta.status} ${resposta.statusText}`);
+    }
+
+    const dados = await resposta.json();
+    return this.converterResposta(dados);
+  }
+
+  private converterResposta(dados: any): ProdutoAfiliadoAmazon[] {
+    const itens = dados.SearchResult?.Items || [];
+    return itens.map((item: any) => ({
+      nome: item.ItemInfo?.Title?.DisplayValue || '',
+      imagem: item.Images?.Primary?.Large?.URL || '',
+      preco: item.Offers?.Listings?.[0]?.Price?.DisplayAmount || '',
+      link: item.DetailPageURL || ''
+    }));
+  }
+
+  private assinarRequisicao(caminho: string, corpo: string): Record<string, string> {
+    const alvo = 'com.amazon.paapi5.v1.ProductAdvertisingAPIv1.SearchItems';
+    const tipoConteudo = 'application/json; charset=UTF-8';
+    const codificacao = 'amz-1.0';
+
+    const agora = new Date();
+    const amzDate = agora.toISOString().replace(/[:-]|\.\d{3}/g, '');
+    const dateStamp = amzDate.slice(0, 8);
+
+    const headers: Record<string, string> = {
+      'content-encoding': codificacao,
+      'content-type': tipoConteudo,
+      host: this.host,
+      'x-amz-date': amzDate,
+      'x-amz-target': alvo
+    };
+
+    const signedHeaders = Object.keys(headers)
+      .map(h => h.toLowerCase())
+      .sort()
+      .join(';');
+    const canonicalHeaders = Object.keys(headers)
+      .map(h => `${h.toLowerCase()}:${headers[h]}`)
+      .sort()
+      .join('\n');
+
+    const hashedPayload = crypto.createHash('sha256').update(corpo, 'utf8').digest('hex');
+
+    const canonicalRequest = [
+      'POST',
+      caminho,
+      '',
+      canonicalHeaders + '\n',
+      signedHeaders,
+      hashedPayload
+    ].join('\n');
+
+    const algorithm = 'AWS4-HMAC-SHA256';
+    const credentialScope = `${dateStamp}/${this.region}/${this.service}/aws4_request`;
+    const stringToSign = [
+      algorithm,
+      amzDate,
+      credentialScope,
+      crypto.createHash('sha256').update(canonicalRequest, 'utf8').digest('hex')
+    ].join('\n');
+
+    const signingKey = this.getSignatureKey(this.secretKey, dateStamp, this.region, this.service);
+    const signature = crypto.createHmac('sha256', signingKey).update(stringToSign, 'utf8').digest('hex');
+
+    const authorization = `${algorithm} Credential=${this.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+    return {
+      ...headers,
+      Authorization: authorization
+    };
+  }
+
+  private getSignatureKey(key: string, dateStamp: string, regionName: string, serviceName: string) {
+    const kDate = crypto.createHmac('sha256', 'AWS4' + key).update(dateStamp).digest();
+    const kRegion = crypto.createHmac('sha256', kDate).update(regionName).digest();
+    const kService = crypto.createHmac('sha256', kRegion).update(serviceName).digest();
+    return crypto.createHmac('sha256', kService).update('aws4_request').digest();
+  }
+}

--- a/src/services/amazon/promocao-amazon.service.ts
+++ b/src/services/amazon/promocao-amazon.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ProdutoAfiliadoAmazon } from '../../model/produto-afiliado-amazon.model';
+
+@Injectable({ providedIn: 'root' })
+export class PromocaoAmazonService {
+  private readonly endpoint = '/api/amazon/promocoes';
+
+  constructor(private http: HttpClient) { }
+
+  listarPromocoes(): Observable<ProdutoAfiliadoAmazon[]> {
+    return this.http.get<ProdutoAfiliadoAmazon[]>(this.endpoint);
+  }
+}


### PR DESCRIPTION
## Resumo
- adicionar modelo `ProdutoAfiliadoAmazon`
- adicionar serviço Node para consumir PA-API v5
- criar serviço Angular para buscar dados do backend
- criar componente de card para produtos da Amazon
- carregar promoções da Amazon na página `/promocoes`
- expor endpoint `/api/amazon/promocoes` no servidor

## Testes
- `npm test` *(falha: Chrome não instalado)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876c11c1eec8332bb2b9ebf1e0140c0