### PR TITLE
feat: add university pages and auth flow

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -10,6 +10,10 @@ import { PromocoesShopeeComponent } from './componentes/paginas/promocoes/promoc
 import { PromocoesDetalhesComponent } from './componentes/paginas/promocoes/promocoes-detalhes/promocoes-detalhes.component';
 import { LoginComponent } from './componentes/paginas/login/login.component';
 import { PainelAdminComponent } from './componentes/paginas/login/painel-admin/painel-admin.component';
+import { UniversityComponent } from './componentes/paginas/university/university.component';
+import { CourseDetailComponent } from './componentes/paginas/university/course-detail/course-detail.component';
+import { StudentDashboardComponent } from './componentes/paginas/university/student-dashboard/student-dashboard.component';
+import { RegisterComponent } from './componentes/paginas/register/register.component';
 import { authGuard } from '../core/guards/auth.guard';
 
 export const routes: Routes = [
@@ -23,5 +27,9 @@ export const routes: Routes = [
     { path: 'promocoes/amazon', component: PromocoesAmazonComponent, title: '@marcospaulo.dev - Promoções Amazon' },
     { path: 'promocoes/kabum', component: PromocoesKabumComponent, title: '@marcospaulo.dev - Kabum' },
     { path: 'promocoes/shopee', component: PromocoesShopeeComponent, title: '@marcospaulo.dev - Shopee' },
-    { path: 'promocoes/aliexpress', component: PromocoesAliexpressComponent, title: '@marcospaulo.dev - AliExpress' }
+    { path: 'promocoes/aliexpress', component: PromocoesAliexpressComponent, title: '@marcospaulo.dev - AliExpress' },
+    { path: 'universidade', component: UniversityComponent, title: 'Universidade' },
+    { path: 'universidade/cursos/:id', component: CourseDetailComponent, canActivate: [authGuard], title: 'Curso' },
+    { path: 'universidade/dashboard', component: StudentDashboardComponent, canActivate: [authGuard], title: 'Meus Cursos' },
+    { path: 'registro', component: RegisterComponent, title: 'Registre-se' }
 ];

--- a/src/app/componentes/paginas/login/login.component.ts
+++ b/src/app/componentes/paginas/login/login.component.ts
@@ -5,7 +5,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { Router } from '@angular/router';
-import { AdminService } from '../../../../core/services/afiliados-repository/admin-repository/admin-repository.service';
+import { AuthService } from '../../../../core/services/afiliados-repository/auth-repository/auth.service';
 
 @Component({
   standalone: true,
@@ -26,16 +26,21 @@ export class LoginComponent {
   erro = '';
 
   constructor(
-    private adminService: AdminService,
+    private authService: AuthService,
     private router: Router
   ) { }
 
   login() {
-    this.adminService.login({ usuario: this.usuario, senha: this.senha })
+    this.authService.login({ usuario: this.usuario, senha: this.senha })
       .subscribe({
         next: (res: any) => {
-          localStorage.setItem('token', res.token);
-          this.router.navigate(['/painel']);
+          localStorage.setItem('token', res.accessToken);
+          const payload = JSON.parse(atob(res.accessToken.split('.')[1]));
+          if (payload.role === 'adm') {
+            this.router.navigate(['/painel']);
+          } else {
+            this.router.navigate(['/universidade/dashboard']);
+          }
         },
         error: () => {
           this.erro = 'Usuário ou senha inválidos';

--- a/src/app/componentes/paginas/register/register.component.html
+++ b/src/app/componentes/paginas/register/register.component.html
@@ -1,0 +1,88 @@
+<div class="register-container">
+  <form [formGroup]="form" (ngSubmit)="registrar()" class="register-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Nome completo</mat-label>
+      <input matInput formControlName="nomeCompleto" required>
+      <mat-error *ngIf="form.get('nomeCompleto')?.hasError('required')">Nome completo é obrigatório</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Email</mat-label>
+      <input matInput type="email" formControlName="email" required>
+      <mat-error *ngIf="form.get('email')?.hasError('required')">Email é obrigatório</mat-error>
+      <mat-error *ngIf="form.get('email')?.hasError('email')">Email inválido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Senha</mat-label>
+      <input matInput type="password" formControlName="senha" required>
+      <mat-error *ngIf="form.get('senha')?.hasError('required')">Senha é obrigatória</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>CPF</mat-label>
+      <input matInput formControlName="cpf" required>
+      <mat-error *ngIf="form.get('cpf')?.hasError('required')">CPF é obrigatório</mat-error>
+      <mat-error *ngIf="form.get('cpf')?.hasError('cpf')">CPF inválido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Telefone</mat-label>
+      <input matInput formControlName="telefone">
+      <mat-error *ngIf="form.get('telefone')?.hasError('pattern')">Telefone inválido</mat-error>
+    </mat-form-field>
+
+    <div formGroupName="endereco" class="endereco-group">
+      <mat-form-field appearance="fill">
+        <mat-label>Rua</mat-label>
+        <input matInput formControlName="rua" required>
+        <mat-error *ngIf="form.get('endereco.rua')?.hasError('required')">Rua é obrigatória</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Número</mat-label>
+        <input matInput formControlName="numero" required>
+        <mat-error *ngIf="form.get('endereco.numero')?.hasError('required')">Número é obrigatório</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Complemento</mat-label>
+        <input matInput formControlName="complemento">
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Bairro</mat-label>
+        <input matInput formControlName="bairro" required>
+        <mat-error *ngIf="form.get('endereco.bairro')?.hasError('required')">Bairro é obrigatório</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Cidade</mat-label>
+        <input matInput formControlName="cidade" required>
+        <mat-error *ngIf="form.get('endereco.cidade')?.hasError('required')">Cidade é obrigatória</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Estado</mat-label>
+        <input matInput formControlName="estado" required>
+        <mat-error *ngIf="form.get('endereco.estado')?.hasError('required')">Estado é obrigatório</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>CEP</mat-label>
+        <input matInput formControlName="cep" required>
+        <mat-error *ngIf="form.get('endereco.cep')?.hasError('required')">CEP é obrigatório</mat-error>
+        <mat-error *ngIf="form.get('endereco.cep')?.hasError('pattern')">CEP inválido</mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>País</mat-label>
+        <input matInput formControlName="pais" required>
+        <mat-error *ngIf="form.get('endereco.pais')?.hasError('required')">País é obrigatório</mat-error>
+      </mat-form-field>
+    </div>
+
+    <button mat-raised-button color="primary" type="submit">Registrar</button>
+    <div class="erro" *ngIf="erro">{{ erro }}</div>
+  </form>
+</div>

--- a/src/app/componentes/paginas/register/register.component.scss
+++ b/src/app/componentes/paginas/register/register.component.scss
@@ -1,0 +1,22 @@
+.register-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.register-form {
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.endereco-group {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.erro {
+  color: red;
+}

--- a/src/app/componentes/paginas/register/register.component.ts
+++ b/src/app/componentes/paginas/register/register.component.ts
@@ -1,0 +1,69 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, AbstractControl, ValidationErrors, FormGroup } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { Router } from '@angular/router';
+import { UserService, CriarUsuarioDto } from '../../../../core/services/afiliados-repository/user-repository/user.service';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  templateUrl: './register.component.html',
+  styleUrl: './register.component.scss'
+})
+export class RegisterComponent {
+  form: FormGroup;
+
+  erro = '';
+
+  constructor(private userService: UserService, private router: Router, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      nomeCompleto: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      senha: ['', Validators.required],
+      cpf: ['', [Validators.required, this.cpfValidator]],
+      telefone: ['', Validators.pattern(/^\d{10,11}$/)],
+      endereco: this.fb.group({
+        rua: ['', Validators.required],
+        numero: ['', Validators.required],
+        complemento: [''],
+        bairro: ['', Validators.required],
+        cidade: ['', Validators.required],
+        estado: ['', Validators.required],
+        cep: ['', [Validators.required, Validators.pattern(/^[0-9]{8}$/)]],
+        pais: ['', Validators.required]
+      })
+    });
+  }
+
+  cpfValidator(control: AbstractControl): ValidationErrors | null {
+    const cpf = control.value ? control.value.replace(/\D/g, '') : '';
+    if (cpf.length !== 11 || /^([0-9])\1+$/.test(cpf)) return { cpf: true };
+    let soma = 0;
+    for (let i = 0; i < 9; i++) soma += Number(cpf.charAt(i)) * (10 - i);
+    let resto = (soma * 10) % 11;
+    if (resto === 10 || resto === 11) resto = 0;
+    if (resto !== Number(cpf.charAt(9))) return { cpf: true };
+    soma = 0;
+    for (let i = 0; i < 10; i++) soma += Number(cpf.charAt(i)) * (11 - i);
+    resto = (soma * 10) % 11;
+    if (resto === 10 || resto === 11) resto = 0;
+    if (resto !== Number(cpf.charAt(10))) return { cpf: true };
+    return null;
+  }
+
+  registrar() {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const dto: CriarUsuarioDto = { ...(this.form.value as any), role: 'aluno' };
+    this.userService.registrar(dto).subscribe({
+      next: () => this.router.navigate(['/login']),
+      error: () => this.erro = 'Erro ao registrar'
+    });
+  }
+}

--- a/src/app/componentes/paginas/university/course-detail/course-detail.component.html
+++ b/src/app/componentes/paginas/university/course-detail/course-detail.component.html
@@ -1,0 +1,20 @@
+<mat-sidenav-container *ngIf="curso">
+  <mat-sidenav mode="side" opened>
+    <mat-nav-list>
+      <a mat-list-item *ngFor="let m of curso.modulos; index as i" (click)="selecionarModulo(i)">
+        {{ m.titulo }}
+      </a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content>
+    <div class="content" *ngIf="curso.modulos[moduloAtual] as modulo">
+      <h2>{{ modulo.titulo }}</h2>
+      <div [innerHTML]="modulo.conteudo"></div>
+      <div class="nav-buttons">
+        <button mat-raised-button color="primary" (click)="anterior()">Anterior</button>
+        <button mat-raised-button color="accent" (click)="proximo()">Próximo</button>
+      </div>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/componentes/paginas/university/course-detail/course-detail.component.scss
+++ b/src/app/componentes/paginas/university/course-detail/course-detail.component.scss
@@ -1,0 +1,13 @@
+mat-sidenav-container {
+  height: 100%;
+}
+
+.content {
+  padding: 1rem;
+}
+
+.nav-buttons {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/app/componentes/paginas/university/course-detail/course-detail.component.ts
+++ b/src/app/componentes/paginas/university/course-detail/course-detail.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
+import { UniversityService } from '../../../../../core/services/afiliados-repository/university-repository/university.service';
+
+@Component({
+  selector: 'app-course-detail',
+  standalone: true,
+  imports: [CommonModule, MatSidenavModule, MatListModule, MatButtonModule],
+  templateUrl: './course-detail.component.html',
+  styleUrl: './course-detail.component.scss'
+})
+export class CourseDetailComponent implements OnInit {
+  curso: any;
+  moduloAtual = 0;
+
+  constructor(
+    private route: ActivatedRoute,
+    private universityService: UniversityService
+  ) { }
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id')!;
+    this.universityService.obterCurso(id).subscribe(res => {
+      this.curso = res;
+    });
+  }
+
+  selecionarModulo(i: number) {
+    this.moduloAtual = i;
+  }
+
+  anterior() {
+    if (this.moduloAtual > 0) {
+      this.moduloAtual--;
+    }
+  }
+
+  proximo() {
+    if (this.curso && this.moduloAtual < this.curso.modulos.length - 1) {
+      this.moduloAtual++;
+    }
+  }
+}

--- a/src/app/componentes/paginas/university/student-dashboard/student-dashboard.component.html
+++ b/src/app/componentes/paginas/university/student-dashboard/student-dashboard.component.html
@@ -1,0 +1,9 @@
+<h1>Meus Cursos</h1>
+<div class="course-list">
+  <mat-card *ngFor="let curso of cursos" class="course-card">
+    <mat-card-title>{{ curso.nome }}</mat-card-title>
+    <mat-card-actions>
+      <a mat-button color="primary" [routerLink]="['/universidade/cursos', curso.id]">Acessar</a>
+    </mat-card-actions>
+  </mat-card>
+</div>

--- a/src/app/componentes/paginas/university/student-dashboard/student-dashboard.component.scss
+++ b/src/app/componentes/paginas/university/student-dashboard/student-dashboard.component.scss
@@ -1,0 +1,9 @@
+.course-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.course-card {
+  width: 300px;
+}

--- a/src/app/componentes/paginas/university/student-dashboard/student-dashboard.component.ts
+++ b/src/app/componentes/paginas/university/student-dashboard/student-dashboard.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { RouterModule } from '@angular/router';
+import { UniversityService } from '../../../../../core/services/afiliados-repository/university-repository/university.service';
+
+@Component({
+  selector: 'app-student-dashboard',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, RouterModule],
+  templateUrl: './student-dashboard.component.html',
+  styleUrl: './student-dashboard.component.scss'
+})
+export class StudentDashboardComponent implements OnInit {
+  cursos: any[] = [];
+
+  constructor(private universityService: UniversityService) { }
+
+  ngOnInit() {
+    this.universityService.listarCursos().subscribe(res => this.cursos = res);
+  }
+}

--- a/src/app/componentes/paginas/university/university.component.html
+++ b/src/app/componentes/paginas/university/university.component.html
@@ -1,0 +1,23 @@
+<section class="about">
+  <h1>Bem-vindo à Universidade</h1>
+  <p>Sou Marcos Paulo Silva, graduado em ... e trabalho com diversas tecnologias como Angular, NestJS, etc.</p>
+  <div class="actions">
+    <a mat-raised-button color="primary" routerLink="/login">Login</a>
+    <a mat-raised-button color="accent" routerLink="/registro">Registre-se</a>
+  </div>
+</section>
+
+<section class="courses" *ngIf="cursos.length">
+  <h2>Cursos Disponíveis</h2>
+  <div class="course-list">
+    <mat-card *ngFor="let curso of cursos" class="course-card">
+      <mat-card-title>{{ curso.nome }}</mat-card-title>
+      <mat-card-content>
+        <p>Módulos: {{ curso.quantidadeModulos }} | Preço: {{ curso.preco | currency:'BRL' }}</p>
+      </mat-card-content>
+      <mat-card-actions>
+        <a mat-button color="primary" [routerLink]="['/universidade/cursos', curso.id]">Ver detalhes</a>
+      </mat-card-actions>
+    </mat-card>
+  </div>
+</section>

--- a/src/app/componentes/paginas/university/university.component.scss
+++ b/src/app/componentes/paginas/university/university.component.scss
@@ -1,0 +1,21 @@
+.about {
+  text-align: center;
+  margin-bottom: 2rem;
+
+  .actions {
+    margin-top: 1rem;
+    a {
+      margin: 0 0.5rem;
+    }
+  }
+}
+
+.course-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.course-card {
+  width: 300px;
+}

--- a/src/app/componentes/paginas/university/university.component.ts
+++ b/src/app/componentes/paginas/university/university.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { RouterModule } from '@angular/router';
+import { UniversityService } from '../../../../core/services/afiliados-repository/university-repository/university.service';
+
+@Component({
+  selector: 'app-university',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, MatButtonModule, RouterModule],
+  templateUrl: './university.component.html',
+  styleUrl: './university.component.scss'
+})
+export class UniversityComponent implements OnInit {
+  cursos: any[] = [];
+
+  constructor(private universityService: UniversityService) { }
+
+  ngOnInit() {
+    this.universityService.listarCursos().subscribe(res => this.cursos = res);
+  }
+}

--- a/src/core/guards/auth.guard.ts
+++ b/src/core/guards/auth.guard.ts
@@ -5,5 +5,5 @@ export const authGuard: CanActivateFn = () => {
     const token = localStorage.getItem('token');
     const router = inject(Router);
 
-    return token ? true : router.createUrlTree(['/admin/login']);
+    return token ? true : router.createUrlTree(['/login']);
 };

--- a/src/core/services/afiliados-repository/auth-repository/auth.service.spec.ts
+++ b/src/core/services/afiliados-repository/auth-repository/auth.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { AdminService } from './admin-repository.service';
+import { AuthService } from './auth.service';
 
-describe('AdminRepositoryService', () => {
-  let service: AdminService;
+describe('AuthService', () => {
+  let service: AuthService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(AdminService);
+    service = TestBed.inject(AuthService);
   });
 
   it('should be created', () => {

--- a/src/core/services/afiliados-repository/auth-repository/auth.service.ts
+++ b/src/core/services/afiliados-repository/auth-repository/auth.service.ts
@@ -6,8 +6,8 @@ import { environment } from '../../../../environments/environments';
   providedIn: 'root'
 })
 
-export class AdminService {
-  private readonly apiUrl = `${environment.apiUrl}/admin`;
+export class AuthService {
+  private readonly apiUrl = `${environment.apiUrl}/auth`;
 
   constructor(private http: HttpClient) { }
 

--- a/src/core/services/afiliados-repository/university-repository/university.service.ts
+++ b/src/core/services/afiliados-repository/university-repository/university.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environments';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UniversityService {
+  private readonly apiUrl = `${environment.apiUrl}/university`;
+
+  constructor(private http: HttpClient) { }
+
+  listarCursos() {
+    return this.http.get<any[]>(`${this.apiUrl}/courses`);
+  }
+
+  obterCurso(id: string) {
+    return this.http.get<any>(`${this.apiUrl}/courses/${id}`);
+  }
+
+  comprarCurso(id: string) {
+    return this.http.post(`${this.apiUrl}/courses/${id}/purchase`, {});
+  }
+
+  salvarProgresso(id: string, moduloAtual: number, percentual: number) {
+    return this.http.put(`${this.apiUrl}/courses/${id}/progress`, { moduloAtual, percentual });
+  }
+}

--- a/src/core/services/afiliados-repository/user-repository/user.service.ts
+++ b/src/core/services/afiliados-repository/user-repository/user.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environments';
+
+export interface Endereco {
+  rua: string;
+  numero: string;
+  complemento?: string;
+  bairro: string;
+  cidade: string;
+  estado: string;
+  cep: string;
+  pais: string;
+}
+
+export interface CriarUsuarioDto {
+  nomeCompleto: string;
+  email: string;
+  senha: string;
+  cpf: string;
+  telefone?: string;
+  endereco: Endereco;
+  role: 'aluno' | 'adm';
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+  private readonly apiUrl = `${environment.apiUrl}/users`;
+
+  constructor(private http: HttpClient) { }
+
+  registrar(dto: CriarUsuarioDto) {
+    return this.http.post(this.apiUrl, dto);
+  }
+}


### PR DESCRIPTION
## Summary
- add university listing, course detail and student dashboard
- add user registration and role-aware login
- wire up University API services and routes
- fix API requests to match updated backend documentation
- validate user registration with full profile fields

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build -- --configuration development`


------
https://chatgpt.com/codex/tasks/task_e_6891f0c99c948332b766c761c10a5bc9