### PR TITLE
feat: enforce admin role in auth guard

### DIFF
--- a/src/core/guards/auth.guard.ts
+++ b/src/core/guards/auth.guard.ts
@@ -1,9 +1,28 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 
-export const authGuard: CanActivateFn = () => {
-    const token = localStorage.getItem('token');
-    const router = inject(Router);
+const decodeToken = (token: string) => {
+  try {
+    const payload = token.split('.')[1];
+    return JSON.parse(atob(payload));
+  } catch {
+    return null;
+  }
+};
 
-    return token ? true : router.createUrlTree(['/admin/login']);
+export const authGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  const token = localStorage.getItem('token');
+
+  if (!token) {
+    return router.createUrlTree(['/login']);
+  }
+
+  const decoded = decodeToken(token);
+
+  if (!decoded || decoded.role?.toLowerCase() !== 'admin') {
+    return router.createUrlTree(['/login']);
+  }
+
+  return true;
 };


### PR DESCRIPTION
## Summary
- decode JWTs and validate `role` in auth guard
- redirect to login when missing token or non-admin role

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module 'url'; Karma load error)*

------
https://chatgpt.com/codex/tasks/task_e_6892c2f906108332b6219a5027bce202