### PR TITLE
Fix i18n loader path for production routes

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -14,7 +14,7 @@ import { APP_INITIALIZER, importProvidersFrom } from '@angular/core';
 import { authInterceptor } from '../core/services/interceptors/auth.interceptor';
 
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
-  return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, 'assets/i18n/', '.json');
 }
 
 export function initTranslateFactory(translate: TranslateService) {


### PR DESCRIPTION
## Summary
- adjust the translation file loader to resolve from the app root so asset requests succeed on nested routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6907c47e8eac8332b2bef99cd8291d38